### PR TITLE
Revert "Bumped actions/cache from v2 to v2.1.4 (#5)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
This reverts commit 57d592b2b9102eb39b94a76d3fec5b5b4e501731.

GitHub Actions are always tagged with "v<major>" actions/cache
had a bug in "v2.1.4", because of that the tag "v2" was set
to "v2.1.3" again.